### PR TITLE
Add bin/pharcc as bin to composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
     },
     "autoload": {
         "psr-0": {"cbednarski": "src/"}
-    }
+    },
+    "bin": [
+        "bin/pharcc"
+    ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "b3418700c8a6716caa9bcc743a95b2bd",
+    "hash": "b75d335f3f5339ec9ae0747e4ecfb6f9",
     "packages": [
         {
             "name": "cbednarski/fileutils",
@@ -80,7 +81,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -127,7 +130,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -174,7 +179,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -196,6 +203,7 @@
     "stability-flags": [
 
     ],
+    "prefer-stable": false,
     "platform": [
 
     ],


### PR DESCRIPTION
This trivial change adds the bin/pharcc script as a bin to the composer config. This allows this project to be installed as a dev dependency in vendor/bin/pharcc or as a global composer dependency.
